### PR TITLE
Configurable fzf keybindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/README.md
+++ b/README.md
@@ -159,8 +159,11 @@ let g:fzf_preview_gitfiles_command = "git status --short --untracked-files=all |
 " Commands used for project grep
 let g:fzf_preview_grep_cmd = 'rg --line-number --no-heading'
 
-" Commands used for preview of the grep result 
+" Commands used for preview of the grep result
 let g:fzf_preview_grep_preview_cmd = expand('<sfile>:h:h') . '/bin/preview.rb'
+
+" Keyboard shortcuts while fzf preview is active
+let g:fzf_preview_default_key_bindings = 'ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'
 ```
 
 # License

--- a/autoload/fzf_preview.vim
+++ b/autoload/fzf_preview.vim
@@ -124,7 +124,8 @@ function! s:fzf_toggle_full_buffer() abort
 endfunction
 
 function! s:fzf_command_common_option(console) abort
-  return '--reverse --ansi --prompt="' . a:console . '>" --bind ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview --preview '
+  return '--reverse --ansi --prompt="' . a:console . '> " --bind '
+        \ . g:fzf_preview_default_key_bindings . ' --preview '
 endfunction
 
 let s:files_prompt     = 'ProjectFiles'

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -181,6 +181,7 @@ g:fzf_preview_gitfiles_command
 
     Default value is "git status --short --untracked-files=all | awk '{if (substr($0,2,1) !~ / /) print $2}'"
 
+
 g:fzf_preview_grep_cmd
     This command is used for project grep.
     Recommend using a fast grep command such as ripgrep or ag.
@@ -201,11 +202,15 @@ g:fzf_preview_grep_preview_cmd
     Default value is 'expand("<sfile>:h:h") . "/bin/preview.rb"'
 
 
+g:fzf_preview_default_key_bindings
+    This command determines keyboard shortcuts during an interactive FZF
+    session. Options are a string passed directly to fzf's "--bind" option.
+
+    Default value is 'ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'
+
+
 ==============================================================================
 KEYMAP                                          *fzf-preview-keymap*
-
-It is currently impossible to change, but we plan to
-make it changeable in the future.
 
 <C-s>
   - Toggle window size of fzf, normal size and full-screen

--- a/plugin/fzf_preview.vim
+++ b/plugin/fzf_preview.vim
@@ -59,6 +59,11 @@ if !exists('g:fzf_preview_grep_preview_cmd')
   let g:fzf_preview_grep_preview_cmd = expand('<sfile>:h:h') . '/bin/preview.rb'
 endif
 
+if !exists('g:fzf_preview_default_key_bindings')
+  let g:fzf_preview_default_key_bindings =
+        \ 'ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'
+endif
+
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 


### PR DESCRIPTION
Provides one new global variable.

g:fzf_preview_default_key_bindings
    This command determines keyboard shortcuts during an interactive FZF
    session. Options are a string passed directly to fzf's "--bind" option.

    Default value is 'ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'

I opted for 1 global variable mapping directly to the command line options because:

1. FZF's key syntax is a bit different than Vim's. Additional abstraction (eg, providing separate variables for each option) would likely be confusing if we just required the key.
2. For users who understand fzf's cli, this solution is simpler
3. Changes very little existing code. It just makes what already exists configurable.

Finally, I added a space after the prompt. Most shells I've worked with have a space after the prompt, and the lack of a space bothered me.
