### PR TITLE
Fix typo in s:buffers()

### DIFF
--- a/autoload/fzf_preview.vim
+++ b/autoload/fzf_preview.vim
@@ -58,7 +58,7 @@ function! s:buffers() abort
   \ "bufexists(v:val) && buflisted(v:val) && filereadable(expand('#' . v:val . ':p'))"
   \ )
   let buffers = map(list, 'bufname(v:val)')
-  return s:convert_for_fzf(files)
+  return s:convert_for_fzf(buffers)
 endfunction
 
 function! s:oldfiles() abort


### PR DESCRIPTION
`s:buffers()` currently looks for `files` when running `s:convert_for_fzf()`, but should use `buffers` defined right above. Fixes https://github.com/yuki-ycino/fzf-preview.vim/issues/28