### PR TITLE
Experimental: Set the arguments to be passed when executing fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,32 @@ let g:fzf_preview_buffer_delete_processors = fzf_preview#resource_processor#get_
 let g:fzf_preview_buffer_delete_processors['ctrl-x'] = function('s:buffers_delete_from_paths')
 
 nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
+
+
+" EXPERIMENTAL: Specifications may change.
+-fzf-args
+" Set the arguments to be passed when executing fzf.
+" Value must be a global variable name.
+" Variable is string and format is shell command options.
+" This option is experimental.
+"
+" Value example: let g:foo_processors = {
+"                \ '':       function('fzf_preview#resource_processor#edit'),
+"                \ 'ctrl-x': function('s:foo_function'),
+"                \ }
+"
+
+" Example: Exclude filename with FzfPreviewProjectGrep
+AutoCmd VimEnter * let g:fzf_preview_command_options = fzf_preview#command#get_common_command_options() |
+  \ let g:fzf_preview_command_options = g:fzf_preview_command_options . ' --nth=3'
+nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-args=g:fzf_preview_command_options<Space>
 ```
 
 ### Function
 
 ```vim
-call fzf_preview#window#create_centered_floating_window() " Function to display the floating window used by this plugin
+" Function to display the floating window used by this plugin
+call fzf_preview#window#create_centered_floating_window()
 
 " Example
 call fzf#run({
@@ -159,6 +179,17 @@ call fzf#run({
 \ 'sink':   'edit',
 \ 'window': 'call fzf_preview#window#create_centered_floating_window()',
 \ })
+
+" Get the initial value of the process executed when selecting the element of fzf
+call fzf_preview#resource_processor#get_default_processors()
+
+" Get the current value of the process executed when selecting the element of fzf
+call fzf_preview#resource_processor#get_processors()
+
+" EXPERIMENTAL: Specifications may change.
+" Get the common value of the passed when executed fzf.
+" Use after VimEnter.
+call fzf_preview#command#get_common_command_options()
 ```
 
 ## Keymap
@@ -300,16 +331,6 @@ let g:fzf_preview_rate = 0.3
 " DEPRECATED
 " Key to toggle fzf window size of normal size and full-screen
 let g:fzf_full_preview_toggle_key = '<C-s>'
-```
-
-## Functions
-
-```vim
-" Get the initial value of the process executed when selecting the element of fzf
-call fzf_preview#resource_processor#get_default_processors()
-
-" Get the current value of the process executed when selecting the element of fzf
-call fzf_preview#resource_processor#get_processors()
 ```
 
 ## Inspiration

--- a/autoload/fzf_preview/args.vim
+++ b/autoload/fzf_preview/args.vim
@@ -1,14 +1,29 @@
 function! fzf_preview#args#parse(args) abort
+  let types = [
+  \ 'processors',
+  \ 'fzf-args',
+  \ ]
+
   let args = {
-  \ 'processors': v:false,
-  \ 'extra': []
+  \ 'extra': [],
   \ }
 
+  for type in types
+    let args[type] = v:false
+  endfor
+
   for arg in a:args
-    let matches = matchlist(arg, '^-processors=\(\(\w\|:\)\+\)$')
-    if len(matches) >= 1
-      let args['processors'] = matches[1]
-    else
+    let if_match = v:false
+
+    for type in types
+      let matches = matchlist(arg, '^-' . type . '=\(\(\w\|:\)\+\)$')
+      if len(matches) >= 1
+        let args[type] = matches[1]
+        let if_match = v:true
+      endif
+    endfor
+
+    if !if_match
       call add(args['extra'], arg)
     endif
   endfor

--- a/autoload/fzf_preview/command.vim
+++ b/autoload/fzf_preview/command.vim
@@ -1,26 +1,37 @@
 function! fzf_preview#command#file_list_command_options(console) abort
   let preview = g:fzf_preview_if_binary_command . ' && ' . g:fzf_binary_preview_command . ' || ' . g:fzf_preview_command
-  return fzf_preview#command#command_options(a:console, preview)
+  return fzf_preview#command#get_command_options(a:console, preview)
 endfunction
 
-function! fzf_preview#command#command_options(console, preview, ...) abort
-  let optional = get(a:, 1, 0) !=# '' ? get(a:, 1, 0) : ''
-
-  let processors = copy(fzf_preview#resource_processor#get_processors())
-  call remove(processors, '')
-  let expect_keys = keys(processors)
-
+function! fzf_preview#command#get_common_command_options() abort
   let multi = '--multi'
-  let fix = '--reverse --ansi'
-  let prompt = '--prompt="' . a:console . '> "'
+  let reverse = '--reverse'
+  let ansi = '--ansi'
   let bind = '--bind=' . g:fzf_preview_preview_key_bindings
   " alt-enter is workaround
-  let expect = len(expect_keys) >= 1 ? '--expect=' . join(expect_keys, ',') : '--expect="alt-enter"'
   let color = g:fzf_preview_fzf_color_option !=# '' ? '--color=' . g:fzf_preview_fzf_color_option : ''
-  let preview = "--preview='" . a:preview . "'"
   let preview_window = g:fzf_preview_fzf_preview_window_option !=# '' ? '--preview-window="' . g:fzf_preview_fzf_preview_window_option . '"' : ''
 
-  return join([multi, fix, prompt, bind, expect, color, preview, preview_window, optional], ' ')
+  return join([multi, reverse, ansi, bind, color, preview_window], ' ')
+endfunction
+
+function! fzf_preview#command#get_command_options(console, preview, ...) abort
+  if !exists('s:options')
+    let s:options = fzf_preview#command#get_common_command_options()
+  endif
+  let optional = get(a:, 1, 0) !=# '' ? get(a:, 1, 0) : ''
+
+  return join([s:options, s:get_uncommon_options(a:console, a:preview, optional)], ' ')
+endfunction
+
+function! fzf_preview#command#set_command_options(options) abort
+  let s:options = a:options
+endfunction
+
+function! fzf_preview#command#reset_command_options() abort
+  if exists('s:options')
+    unlet s:options
+  endif
 endfunction
 
 function! fzf_preview#command#grep_command(args) abort
@@ -33,4 +44,16 @@ endfunction
 
 function! fzf_preview#command#buffer_tags_command(file) abort
   return 'ctags -f - --sort=yes --excmd=number ' . a:file
+endfunction
+
+function! s:get_uncommon_options(console, preview, optional) abort
+  let processors = copy(fzf_preview#resource_processor#get_processors())
+  call remove(processors, '')
+  let expect_keys = keys(processors)
+
+  let expect = len(expect_keys) >= 1 ? '--expect=' . join(expect_keys, ',') : '--expect="alt-enter"'
+  let prompt = '--prompt="' . a:console . '> "'
+  let preview = "--preview='" . a:preview . "'"
+
+  return join([expect, prompt, preview, a:optional], ' ')
 endfunction

--- a/autoload/fzf_preview/initializer.vim
+++ b/autoload/fzf_preview/initializer.vim
@@ -7,5 +7,11 @@ function! fzf_preview#initializer#initialize(func_name, additional, ...) abort
     call fzf_preview#resource_processor#set_processors(processors)
   endif
 
+  call fzf_preview#command#reset_command_options()
+  if args['fzf-args'] != v:false
+    let fzf_args = eval(args['fzf-args'])
+    call fzf_preview#command#set_command_options(fzf_args)
+  endif
+
   return fzf_preview#parameter#build_parameter(a:func_name, a:additional, args['extra'])
 endfunction

--- a/autoload/fzf_preview/parameter.vim
+++ b/autoload/fzf_preview/parameter.vim
@@ -28,7 +28,7 @@ function! s:git_status(additional, args) abort
   return {
   \ 'source': fzf_preview#resource#git_status(),
   \ 'sink': function('fzf_preview#handler#handle_git_status'),
-  \ 'options': fzf_preview#command#command_options('GitStatus', preview)
+  \ 'options': fzf_preview#command#get_command_options('GitStatus', preview)
   \ }
 endfunction
 
@@ -79,7 +79,7 @@ function! s:locationlist(additional, args) abort
   return {
   \ 'source': resource,
   \ 'sink': function('fzf_preview#handler#handle_grep'),
-  \ 'options': fzf_preview#command#command_options(a:additional['type'], preview, optional)
+  \ 'options': fzf_preview#command#get_command_options(a:additional['type'], preview, optional)
   \ }
 endfunction
 
@@ -90,7 +90,7 @@ function! s:project_grep(additional, args) abort
   return {
   \ 'source': fzf_preview#resource#grep(join(a:args, ' ')),
   \ 'sink': function('fzf_preview#handler#handle_grep'),
-  \ 'options': fzf_preview#command#command_options('ProjectGrep', preview, optional)
+  \ 'options': fzf_preview#command#get_command_options('ProjectGrep', preview, optional)
   \ }
 endfunction
 
@@ -101,7 +101,7 @@ function! s:buffer_tags(additional, args) abort
   return {
   \ 'source': fzf_preview#resource#buffer_tags(),
   \ 'sink': function('fzf_preview#handler#handle_buffer_tags'),
-  \ 'options': fzf_preview#command#command_options('BufferTags', preview, optional)
+  \ 'options': fzf_preview#command#get_command_options('BufferTags', preview, optional)
   \ }
 endfunction
 
@@ -112,7 +112,7 @@ function! s:jumps(additional, args) abort
   return {
   \ 'source': fzf_preview#resource#jumps(),
   \ 'sink': function('fzf_preview#handler#handle_grep'),
-  \ 'options': fzf_preview#command#command_options('Jumps', preview, optional)
+  \ 'options': fzf_preview#command#get_command_options('Jumps', preview, optional)
   \ }
 endfunction
 
@@ -123,7 +123,7 @@ function! s:bookmarks(additional, args) abort
   return {
   \ 'source': fzf_preview#resource#bookmarks(),
   \ 'sink': function('fzf_preview#handler#handle_grep'),
-  \ 'options': fzf_preview#command#command_options('Bookmarks', preview, optional)
+  \ 'options': fzf_preview#command#get_command_options('Bookmarks', preview, optional)
   \ }
 endfunction
 

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -206,6 +206,22 @@ COMMAND OPTIONS                                 *fzf-preview-command-options*
     nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
 <
 
+EXPERIMENTAL: Specifications may change.
+-fzf-args
+    Set the arguments to be passed when executing fzf.
+    Value must be a global variable name.
+    Variable is string and format is shell command options.
+    This option is experimental.
+
+    Value example: let g:foo_arguments = '--multi --reverse --ansi --bind=ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'
+
+    Usage example: Exclude filename with FzfPreviewProjectGrep
+>
+    AutoCmd VimEnter * let g:fzf_preview_command_options = fzf_preview#command#get_common_command_options() |
+      \ let g:fzf_preview_command_options = g:fzf_preview_command_options . ' --nth=3'
+    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-args=g:fzf_preview_command_options<Space>
+<
+
 ==============================================================================
 OPTIONS                                         *fzf-preview-options*
 
@@ -432,6 +448,14 @@ FUNCTIONS                                       *fzf-preview-functions*
 *fzf_preview#resource_processor#get_processors*
     Get the current value of the process executed
     when selecting the element of fzf
+
+
+EXPERIMENTAL: Specifications may change.
+*fzf_preview#command#get_common_command_options*
+    Get the common value of the passed when executed fzf.
+    Use after VimEnter.
+
+    value is: '--multi --reverse --ansi --bind=ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'
 
 ==============================================================================
 DEFAULT KEYMAP                                  *fzf-preview-keymap*


### PR DESCRIPTION
Added `-fzf-args` option
This option is experimental.

Set the arguments to be passed when executing fzf.

Example: Exclude filename with FzfPreviewProjectGrep

```vim
autocmd VimEnter * let g:fzf_preview_grep_command_options = fzf_preview#command#get_common_command_options() |
  \ let g:fzf_preview_grep_command_options = g:fzf_preview_grep_command_options . ' --nth=3'
nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-args=g:fzf_preview_grep_command_options<Space>
```