### PR TITLE
Experimental AllBuffers command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ call dein#add('yuki-ycino/fzf-preview.vim')
 
 :FzfPreviewGitStatus                  " Select git status listed file
 
-:FzfPreviewBuffers                    " Select buffers
+:FzfPreviewBuffers                    " Select file buffers
+
+:FzfPreviewAllBuffers                 " Select all buffers
 
 :FzfPreviewProjectOldFiles            " Select project files from oldfiles
 
@@ -130,6 +132,9 @@ call dein#add('yuki-ycino/fzf-preview.vim')
 " Value must be a global variable name.
 " Variable is dictionary and format is same as g:fzf_preview_custom_default_processors.
 "
+" Most commands are passed a file path to the processor function.
+" FzfPreviewAllBuffers will be passed “buffer {bufnr}”
+"
 " Value example: let g:foo_processors = {
 "                \ '':       function('fzf_preview#resource_processor#edit'),
 "                \ 'ctrl-x': function('s:foo_function'),
@@ -145,12 +150,17 @@ augroup END
 
 function! s:fzf_preview_settings() abort
   let g:fzf_preview_buffer_delete_processors = fzf_preview#resource_processor#get_default_processors()
-  let g:fzf_preview_buffer_delete_processors['ctrl-x'] = function('s:buffers_delete_from_paths')
+  let g:fzf_preview_buffer_delete_processors['ctrl-x'] = function('s:buffers_delete_from_lines')
 endfunction
 
-function! s:buffers_delete_from_paths(paths) abort
-  for path in a:paths
-    execute 'bdelete! ' . path
+function! s:buffers_delete_from_lines(lines) abort
+  for line in a:lines
+    let matches = matchlist(line, '^buffer \(\d\+\)$')
+    if len(matches) >= 1
+      execute 'bdelete! ' . matches[1]
+    else
+      execute 'bdelete! ' . line
+    endif
   endfor
 endfunction
 

--- a/autoload/fzf_preview/handler.vim
+++ b/autoload/fzf_preview/handler.vim
@@ -21,6 +21,12 @@ function! fzf_preview#handler#handle_git_status(lines) abort
   call fzf_preview#handler#handle_resource(a:lines, 1, 3)
 endfunction
 
+function! fzf_preview#handler#handle_all_buffers(lines) abort
+  let key = [a:lines[0]]
+  let lines = map(copy(a:lines[1:]), { _, line -> 'buffer ' . split(line)[0] })
+  call fzf_preview#handler#handle_resource(key + lines, 1)
+endfunction
+
 function! fzf_preview#handler#handle_grep(lines) abort
   let optional_discard_prefix_size = g:fzf_preview_use_dev_icons ? g:fzf_preview_dev_icon_prefix_length : 0
   call fzf_preview#handler#handle_resource(a:lines, 1, optional_discard_prefix_size)

--- a/autoload/fzf_preview/parameter.vim
+++ b/autoload/fzf_preview/parameter.vim
@@ -39,6 +39,15 @@ function! s:buffers(additional, args) abort
   \ }
 endfunction
 
+function! s:all_buffers(additional, args) abort
+  let preview = '[[ -f {2..} ]] && ' . g:fzf_preview_command . ' || echo "{2..} is not file."'
+  return {
+  \ 'source': fzf_preview#resource#all_buffers(),
+  \ 'sink': function('fzf_preview#handler#handle_all_buffers'),
+  \ 'options': fzf_preview#command#get_command_options('AllBuffers', preview)
+  \ }
+endfunction
+
 function! s:project_oldfiles(additional, args) abort
   return {
   \ 'source': fzf_preview#resource#project_oldfiles(),

--- a/autoload/fzf_preview/resource.vim
+++ b/autoload/fzf_preview/resource.vim
@@ -38,6 +38,23 @@ function! fzf_preview#resource#buffers() abort
   return fzf_preview#converter#convert_for_fzf(buffers)
 endfunction
 
+function! fzf_preview#resource#all_buffers() abort
+  let buffers = []
+  for bufinfo in copy(getbufinfo())
+    let buffer = {
+    \ 'name': fnamemodify(bufinfo['name'], ':.'),
+    \ 'bufnr': bufinfo['bufnr'],
+    \ }
+    call add(buffers, buffer)
+  endfor
+
+  let buffers = map(copy(getbufinfo({ 'buflisted': 1 })),
+  \ { _, buffer -> [buffer['bufnr'], fnamemodify(buffer['name'], ':.')] }
+  \ )
+
+  return map(copy(fzf_preview#util#align_lists(buffers)), { _, buffer -> join(buffer, ' ') })
+endfunction
+
 function! fzf_preview#resource#project_oldfiles() abort
   if !fzf_preview#util#is_git_directory()
     return []

--- a/autoload/fzf_preview/resource_processor.vim
+++ b/autoload/fzf_preview/resource_processor.vim
@@ -35,25 +35,25 @@ function! fzf_preview#resource_processor#reset_processors() abort
   endif
 endfunction
 
-function! fzf_preview#resource_processor#edit(paths) abort
-  call s:open_file('edit', a:paths)
+function! fzf_preview#resource_processor#edit(lines) abort
+  call s:open_files('edit', a:lines)
 endfunction
 
-function! fzf_preview#resource_processor#split(paths) abort
-  call s:open_file('split', a:paths)
+function! fzf_preview#resource_processor#split(lines) abort
+  call s:open_files('split', a:lines)
 endfunction
 
-function! fzf_preview#resource_processor#vsplit(paths) abort
-  call s:open_file('vertical split', a:paths)
+function! fzf_preview#resource_processor#vsplit(lines) abort
+  call s:open_files('vertical split', a:lines)
 endfunction
 
-function! fzf_preview#resource_processor#tabedit(paths) abort
-  call s:open_file('tabedit', a:paths)
+function! fzf_preview#resource_processor#tabedit(lines) abort
+  call s:open_files('tabedit', a:lines)
 endfunction
 
-function! fzf_preview#resource_processor#export_quickfix(paths) abort
+function! fzf_preview#resource_processor#export_quickfix(lines) abort
   let items = []
-  for path in copy(a:paths)
+  for path in copy(a:lines)
     let filepath_and_line_number_and_text = s:split_path_into_filename_line_number_and_text(path)
     let item = {}
     let item['filename'] = filepath_and_line_number_and_text[0]
@@ -78,16 +78,29 @@ function! s:initialize_processors() abort
   endif
 endfunction
 
-function! s:open_file(open_command, paths) abort
-  for path in copy(a:paths)
-    let filepath_and_line_number = s:split_path_into_filename_line_number_and_text(path)
-    let file_path = filepath_and_line_number[0]
-    let line_number = len(filepath_and_line_number) >= 2 ? filepath_and_line_number[1] : v:false
-    execute join(['silent', a:open_command, file_path], ' ')
-    if line_number
-      call cursor(line_number, 0)
+function! s:open_files(open_command, lines) abort
+  for line in copy(a:lines)
+    let matches = matchlist(line, '^buffer \(\d\+\)$')
+    if len(matches) >= 1
+      call s:open_buffer(a:open_command, matches[1])
+    else
+      call s:open_file_from_filepath(a:open_command, line)
     endif
   endfor
+endfunction
+
+function! s:open_file_from_filepath(command, path) abort
+  let filepath_and_line_number = s:split_path_into_filename_line_number_and_text(a:path)
+  let file_path = filepath_and_line_number[0]
+  let line_number = len(filepath_and_line_number) >= 2 ? filepath_and_line_number[1] : v:false
+  execute join(['silent', a:command, file_path], ' ')
+  if line_number
+    call cursor(line_number, 0)
+  endif
+endfunction
+
+function! s:open_buffer(command, bufnr) abort
+  execute join(['silent', a:command, '|', 'buffer', a:bufnr], ' ')
 endfunction
 
 function! s:split_path_into_filename_line_number_and_text(path) abort

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -111,9 +111,15 @@ COMMANDS                                        *fzf-preview-commands*
 
                                                 *:FzfPreviewBuffers*
 :FzfPreviewBuffers
-     Select and open opened buffers with fzf interface while watching preview.
+     Select and open file buffers.
+
+                                                *:FzfPreviewAllBuffers*
+:FzfPreviewBuffers
+     Select and open all buffers(include not file).
+     Pass the value to the processor function in the format "buffer {bufnr}""
 
                                                 *:FzfPreviewProjectOldFiles*
+
 :FzfPreviewProjectOldFiles
      Select and open the past open files in the project using fzf.
      The target file is selected from  |v:oldfiles|.
@@ -188,6 +194,9 @@ COMMAND OPTIONS                                 *fzf-preview-command-options*
     Variable is dictionary and format is
     same as |g:fzf_preview_custom_default_processors|.
 
+    Most commands are passed a file path to the processor function.
+    FzfPreviewAllBuffers will be passed “buffer {bufnr}”
+
     Value example: let g:foo_processors = {
                    \ '':       function('fzf_preview#resource_processor#edit'),
                    \ 'ctrl-x': function('s:foo_function'),
@@ -202,12 +211,17 @@ COMMAND OPTIONS                                 *fzf-preview-command-options*
 
     function! s:fzf_preview_settings() abort
       let g:fzf_preview_buffer_delete_processors = fzf_preview#resource_processor#get_default_processors()
-      let g:fzf_preview_buffer_delete_processors['ctrl-x'] = function('s:buffers_delete_from_paths')
+      let g:fzf_preview_buffer_delete_processors['ctrl-x'] = function('s:buffers_delete_from_lines')
     endfunction
 
-    function! s:buffers_delete_from_paths(paths) abort
-      for path in a:paths
-        execute 'bdelete! ' . path
+    function! s:buffers_delete_from_lines(lines) abort
+      for line in a:lines
+        let matches = matchlist(line, '^buffer \(\d\+\)$')
+        if len(matches) >= 1
+          execute 'bdelete! ' . matches[1]
+        else
+          execute 'bdelete! ' . line
+        endif
       endfor
     endfunction
 

--- a/plugin/fzf_preview.vim
+++ b/plugin/fzf_preview.vim
@@ -122,6 +122,7 @@ command! -nargs=* -complete=customlist,fzf_preview#args#complete_options        
 command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewDirectoryFiles  :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:directory_files', {}, <f-args>))
 command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewGitStatus       :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:git_status', {}, <f-args>))
 command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewBuffers         :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:buffers', {}, <f-args>))
+command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewAllBuffers      :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:all_buffers', {}, <f-args>))
 command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewProjectOldFiles :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:project_old_files', {}, <f-args>))
 command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewProjectMruFiles :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:project_mru_files', {}, <f-args>))
 command! -nargs=* -complete=customlist,fzf_preview#args#complete_options         FzfPreviewBufferTags      :call fzf_preview#runner#fzf_run(fzf_preview#initializer#initialize('s:buffer_tags', {}, <f-args>))


### PR DESCRIPTION
Added FzfPreviewAllBuffers command.
The format received by processors is `buffer {bufnr}`.

bdelete! example

```vim
function! s:buffers_delete_from_paths(lines) abort
  for line in a:lines
    let matches = matchlist(line, '^buffer \(\d\+\)$')
    if len(matches) >= 1
      execute 'bdelete! ' . matches[1]
    else
      execute 'bdelete! ' . line
    endif
  endfor
endfunction

let g:fzf_preview_buffer_delete_processors = fzf_preview#resource_processor#get_processors()
let g:fzf_preview_buffer_delete_processors['ctrl-x'] = function('s:buffers_delete_from_paths')

nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
nnoremap <silent> <Leader>B :<C-u>FzfPreviewAllBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>

```