### PR TITLE
Add -fzf-arg option and rename -eval-fzf-args option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,16 @@ endfunction
 nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
 
 
+-fzf-arg
+" Set the arguments to be passed when executing fzf.
+" Value must be a string without spaces.
+
+" Example: Exclude filename with FzfPreviewProjectGrep
+nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-arg=--nth=3<Space>
+
+
 " EXPERIMENTAL: Specifications may change.
--fzf-args
+-eval-fzf-args
 " Set the arguments to be passed when executing fzf.
 " Value must be a global variable name.
 " Variable is string and format is shell command options.
@@ -188,7 +196,7 @@ function! s:fzf_preview_settings() abort
   let g:fzf_preview_grep_command_options = g:fzf_preview_grep_command_options . ' --nth=3'
 endfunction
 
-nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-args=g:fzf_preview_grep_command_options<Space>
+nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -eval-fzf-args=g:fzf_preview_grep_command_options<Space>
 ```
 
 ### Function

--- a/README.md
+++ b/README.md
@@ -173,10 +173,7 @@ nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_bu
 " Variable is string and format is shell command options.
 " This option is experimental.
 "
-" Value example: let g:foo_processors = {
-"                \ '':       function('fzf_preview#resource_processor#edit'),
-"                \ 'ctrl-x': function('s:foo_function'),
-"                \ }
+" Value example: let g:foo_arguments = '--multi --reverse --ansi --bind=ctrl-d:preview-page-down,ctrl-u:preview-page-up,?:toggle-preview'
 "
 
 " Example: Exclude filename with FzfPreviewProjectGrep

--- a/autoload/fzf_preview/args.vim
+++ b/autoload/fzf_preview/args.vim
@@ -1,7 +1,8 @@
 function! fzf_preview#args#parse(args) abort
   let types = [
   \ 'processors',
-  \ 'fzf-args',
+  \ 'fzf-arg',
+  \ 'eval-fzf-args',
   \ ]
 
   let args = {
@@ -9,16 +10,16 @@ function! fzf_preview#args#parse(args) abort
   \ }
 
   for type in types
-    let args[type] = v:false
+    let args[type] = ''
   endfor
 
   for arg in a:args
     let if_match = v:false
 
     for type in types
-      let matches = matchlist(arg, '^-' . type . '=\(\(\w\|:\)\+\)$')
+      let matches = matchlist(arg, '^-' . type . '=\(\(\S\)\+\)$')
       if len(matches) >= 1
-        let args[type] = matches[1]
+        let args[type] = args[type] . ' ' . matches[1]
         let if_match = v:true
       endif
     endfor

--- a/autoload/fzf_preview/initializer.vim
+++ b/autoload/fzf_preview/initializer.vim
@@ -1,17 +1,24 @@
 function! fzf_preview#initializer#initialize(func_name, additional, ...) abort
-  let args = fzf_preview#args#parse(a:000)
-
   call fzf_preview#resource_processor#reset_processors()
-  if args['processors'] != v:false
+  call fzf_preview#command#reset_command_options()
+
+  let args = fzf_preview#args#parse(a:000)
+  let fzf_args = ''
+
+  if args['processors'] != ''
     let processors = eval(args['processors'])
     call fzf_preview#resource_processor#set_processors(processors)
   endif
 
-  call fzf_preview#command#reset_command_options()
-  if args['fzf-args'] != v:false
-    let fzf_args = eval(args['fzf-args'])
-    call fzf_preview#command#set_command_options(fzf_args)
+
+  if args['fzf-arg'] != ''
+    let fzf_args = fzf_args . args['fzf-arg']
   endif
 
+  if args['eval-fzf-args'] != ''
+    let fzf_args = fzf_args . eval(args['eval-fzf-args'])
+  endif
+
+  call fzf_preview#command#set_command_options(fzf_args)
   return fzf_preview#parameter#build_parameter(a:func_name, a:additional, args['extra'])
 endfunction

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -223,8 +223,17 @@ COMMAND OPTIONS                                 *fzf-preview-command-options*
     nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
 <
 
+-fzf-arg
+    Set the arguments to be passed when executing fzf.
+    Value must be a string without spaces.
+
+    Usage example: Exclude filename with FzfPreviewProjectGrep
+>
+    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-arg=--nth=3<Space>
+<
+
 EXPERIMENTAL: Specifications may change.
--fzf-args
+-eval-fzf-args
     Set the arguments to be passed when executing fzf.
     Value must be a global variable name.
     Variable is string and format is shell command options.
@@ -244,7 +253,7 @@ EXPERIMENTAL: Specifications may change.
       let g:fzf_preview_grep_command_options = g:fzf_preview_grep_command_options . ' --nth=3'
     endfunction
 
-    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-args=g:fzf_preview_grep_command_options<Space>
+    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -eval-fzf-args=g:fzf_preview_grep_command_options<Space>
 <
 
 ==============================================================================


### PR DESCRIPTION
Added `-fzf-arg` option.
By using the `-fzf-arg` option, it is possible to pass arguments to fzf.

Example: Exclude filename with FzfPreviewProjectGrep

```vim
nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-arg=--nth=3<CR>
```

The name of the `-fzf-args` option has been changed to `-eval-fzf-args`.