### PR TITLE
Renamed -fzf-arg and -eval-fzf-args options

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,17 +168,17 @@ endfunction
 nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
 
 
--fzf-arg
+-add-fzf-arg
 " Set the arguments to be passed when executing fzf.
 " This value is added to the default options.
 " Value must be a string without spaces.
 
 " Example: Exclude filename with FzfPreviewProjectGrep
-nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-arg=--nth=3<Space>
+nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -add-fzf-arg=--nth=3<Space>
 
 
 " EXPERIMENTAL: Specifications may change.
--eval-fzf-args
+-overwrite-fzf-args
 " Set the arguments to be passed when executing fzf.
 " Value must be a global variable name.
 " Variable is string and format is shell command options.
@@ -199,7 +199,7 @@ function! s:fzf_preview_settings() abort
   let g:fzf_preview_grep_command_options = g:fzf_preview_grep_command_options . ' --nth=3'
 endfunction
 
-nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -eval-fzf-args=g:fzf_preview_grep_command_options<Space>
+nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -overwrite-fzf-args=g:fzf_preview_grep_command_options<Space>
 ```
 
 ### Function

--- a/autoload/fzf_preview/args.vim
+++ b/autoload/fzf_preview/args.vim
@@ -1,8 +1,8 @@
 function! fzf_preview#args#parse(args) abort
   let types = [
   \ 'processors',
-  \ 'fzf-arg',
-  \ 'eval-fzf-args',
+  \ 'add-fzf-arg',
+  \ 'overwrite-fzf-args',
   \ ]
 
   let args = {

--- a/autoload/fzf_preview/initializer.vim
+++ b/autoload/fzf_preview/initializer.vim
@@ -10,13 +10,13 @@ function! fzf_preview#initializer#initialize(func_name, additional, ...) abort
   endif
 
 
-  if args['fzf-arg'] != ''
-    let fzf_args = fzf_preview#command#get_common_command_options() . args['fzf-arg']
-    call fzf_preview#command#set_command_options(fzf_args)
+  if args['add-fzf-arg'] != ''
+    let add_fzf_args = fzf_preview#command#get_common_command_options() . args['add-fzf-arg']
+    call fzf_preview#command#set_command_options(add_fzf_args)
   endif
 
-  if args['eval-fzf-args'] != ''
-    call fzf_preview#command#set_command_options(eval(args['eval-fzf-args']))
+  if args['overwrite-fzf-args'] != ''
+    call fzf_preview#command#set_command_options(eval(args['overwrite-fzf-args']))
   endif
 
   return fzf_preview#parameter#build_parameter(a:func_name, a:additional, args['extra'])

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -228,18 +228,18 @@ COMMAND OPTIONS                                 *fzf-preview-command-options*
     nnoremap <silent> <Leader>b :<C-u>FzfPreviewBuffers -processors=g:fzf_preview_buffer_delete_processors<CR>
 <
 
--fzf-arg
+-add-fzf-arg
     Set the arguments to be passed when executing fzf.
     This value is added to the default options.
     Value must be a string without spaces.
 
     Usage example: Exclude filename with FzfPreviewProjectGrep
 >
-    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -fzf-arg=--nth=3<Space>
+    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -add-fzf-arg=--nth=3<Space>
 <
 
 EXPERIMENTAL: Specifications may change.
--eval-fzf-args
+-overwrite-fzf-args
     Set the arguments to be passed when executing fzf.
     Value must be a global variable name.
     Variable is string and format is shell command options.
@@ -259,7 +259,7 @@ EXPERIMENTAL: Specifications may change.
       let g:fzf_preview_grep_command_options = g:fzf_preview_grep_command_options . ' --nth=3'
     endfunction
 
-    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -eval-fzf-args=g:fzf_preview_grep_command_options<Space>
+    nnoremap <Leader>g :<C-u>FzfPreviewProjectGrep -overwrite-fzf-args=g:fzf_preview_grep_command_options<Space>
 <
 
 ==============================================================================


### PR DESCRIPTION
The names of the -fzf-arg and -eval-fzf-args options were changed because they seemed to be confusing.