### PR TITLE
fix: doautocmd need silent

### DIFF
--- a/plugin/fzf_preview.vim
+++ b/plugin/fzf_preview.vim
@@ -146,7 +146,7 @@ augroup fzf_preview_buffers
   endif
 augroup END
 
-doautocmd User fzf_preview#initialized
+silent doautocmd User fzf_preview#initialized
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Currently `doautocmd User fzf_preview#initialized` noisy work.

add suppress non event time message add `silent` command.