### PR TITLE
Remove sort from dircolors example

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ let g:fzf_preview_fzf_preview_window_option = ''
 
 " Command to be executed after file list creation
 let g:fzf_preview_filelist_postprocess_command = ''
-" let g:fzf_preview_filelist_postprocess_command = 'xargs -d "\n" ls —color'          " Use dircolors
+" let g:fzf_preview_filelist_postprocess_command = 'xargs -d "\n" ls -U --color'      " Use dircolors
 " let g:fzf_preview_filelist_postprocess_command = 'xargs -d "\n" exa --color=always' " Use exa
 
 " Use vim-devicons


### PR DESCRIPTION
The current example with using dircolors (ls --color) to color file list, results in ls sorting the file list alphabetically, which is a problem for commands like FzfPreviewOldfiles.