### PR TITLE
Add optional path parameter for directory files list

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,43 +90,43 @@ call dein#add('yuki-ycino/fzf-preview.vim')
 ### Command
 
 ```vim
-:FzfPreviewProjectFiles               " Select project files
+:FzfPreviewProjectFiles                    " Select project files
 
-:FzfPreviewGitFiles                   " Select file from git ls-files
+:FzfPreviewGitFiles                        " Select file from git ls-files
 
-:FzfPreviewDirectoryFiles             " Select file from current directory files (Required [ripgrep](https://github.com/BurntSushi/ripgrep))
+:FzfPreviewDirectoryFiles {path or none}   " Select file from directory files (default to current working directory) (Required [ripgrep](https://github.com/BurntSushi/ripgrep))
 
-:FzfPreviewGitStatus                  " Select git status listed file
+:FzfPreviewGitStatus                       " Select git status listed file
 
-:FzfPreviewBuffers                    " Select file buffers
+:FzfPreviewBuffers                         " Select file buffers
 
-:FzfPreviewAllBuffers                 " Select all buffers
+:FzfPreviewAllBuffers                      " Select all buffers
 
-:FzfPreviewProjectOldFiles            " Select project files from oldfiles
+:FzfPreviewProjectOldFiles                 " Select project files from oldfiles
 
-:FzfPreviewProjectMruFiles            " Select project mru files with neomru
+:FzfPreviewProjectMruFiles                 " Select project mru files with neomru
 
-:FzfPreviewProjectGrep {word or none} " Grep project files from args word (Required [Python3](https://www.python.org/))
+:FzfPreviewProjectGrep {word or none}      " Grep project files from args word (Required [Python3](https://www.python.org/))
 
-:FzfPreviewBufferTags                 " Select tags from current files (Required [Python3](https://www.python.org/))
+:FzfPreviewBufferTags                      " Select tags from current files (Required [Python3](https://www.python.org/))
 
-:FzfPreviewOldFiles                   " Select files from oldfiles
+:FzfPreviewOldFiles                        " Select files from oldfiles
 
-:FzfPreviewMruFiles                   " Select mru files from neomru
+:FzfPreviewMruFiles                        " Select mru files from neomru
 
-:FzfPreviewQuickFix                   " Select line from QuickFix (Required [Python3](https://www.python.org/))
+:FzfPreviewQuickFix                        " Select line from QuickFix (Required [Python3](https://www.python.org/))
 
-:FzfPreviewLocationList               " Select line from LocationList (Required [Python3](https://www.python.org/))
+:FzfPreviewLocationList                    " Select line from LocationList (Required [Python3](https://www.python.org/))
 
-:FzfPreviewLines                      " Select line from current buffer (Required [Python3](https://www.python.org/))
+:FzfPreviewLines                           " Select line from current buffer (Required [Python3](https://www.python.org/))
 
-:FzfPreviewJumps                      " Select jumplist item (Required [Python3](https://www.python.org/))
+:FzfPreviewJumps                           " Select jumplist item (Required [Python3](https://www.python.org/))
 
-:FzfPreviewChanges                    " Select changelist item (Required [Python3](https://www.python.org/))
+:FzfPreviewChanges                         " Select changelist item (Required [Python3](https://www.python.org/))
 
-:FzfPreviewMarks                      " Select mark (Required [Python3](https://www.python.org/))
+:FzfPreviewMarks                           " Select mark (Required [Python3](https://www.python.org/))
 
-:FzfPreviewFromResources              " Select files from selected resources (project, git, directory, buffer, project_old, project_mru, old, mru)
+:FzfPreviewFromResources                   " Select files from selected resources (project, git, directory, buffer, project_old, project_mru, old, mru)
 ```
 
 ### Recommended mappings

--- a/autoload/fzf_preview/parameter.vim
+++ b/autoload/fzf_preview/parameter.vim
@@ -17,8 +17,10 @@ function! s:git_files(additional, args) abort
 endfunction
 
 function! s:directory_files(additional, args) abort
+  let path = get(a:args, 0, '')
+
   return {
-  \ 'source': fzf_preview#resource#directory_files(),
+  \ 'source': fzf_preview#resource#directory_files(path),
   \ 'prompt': 'DirectoryFiles',
   \ }
 endfunction

--- a/autoload/fzf_preview/resource.vim
+++ b/autoload/fzf_preview/resource.vim
@@ -16,8 +16,9 @@ function! fzf_preview#resource#git_files() abort
   return fzf_preview#converter#convert_for_fzf(files)
 endfunction
 
-function! fzf_preview#resource#directory_files() abort
-  let files = systemlist(g:fzf_preview_directory_files_command)
+function! fzf_preview#resource#directory_files(path) abort
+  let files = systemlist(g:fzf_preview_directory_files_command . ' ' . a:path)
+
   return fzf_preview#converter#convert_for_fzf(files)
 endfunction
 
@@ -190,7 +191,7 @@ function! fzf_preview#resource#files_from_resources(resources) abort
   let resource_map = {
   \ 'project': function('fzf_preview#resource#project_files'),
   \ 'git': function('fzf_preview#resource#git_files'),
-  \ 'directory': function('fzf_preview#resource#directory_files'),
+  \ 'directory': function('fzf_preview#resource#directory_files', ['']),
   \ 'buffer': function('fzf_preview#resource#buffers'),
   \ 'project_old': function('fzf_preview#resource#project_oldfiles'),
   \ 'project_mru': function('fzf_preview#resource#project_mrufiles'),

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -94,9 +94,10 @@ COMMANDS                                        *fzf-preview-commands*
      while watching preview.
 
                                                 *:FzfPreviewDirectoryFiles*
-:FzfPreviewDirectoryFiles
-     Select and open current directory files from ripgrep with fzf interface
+:FzfPreviewDirectoryFiles {path or none}
+     Select and open directory files from ripgrep with fzf interface
      while watching preview.
+     Default to current working directory.
      Require ripgrep.
 
                                                 *:FzfPreviewGitStatus*

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -357,6 +357,8 @@ OPTIONS                                         *fzf-preview-options*
 
     Default value is 'rg --files --hidden --follow --no-messages -g \!"* *"'
 
+    Keep in mind a path can be append at the end of the command.
+
 
 *g:fzf_preview_git_status_command*
     This is the command used to git status files


### PR DESCRIPTION
Fixes #83 

This adds an optional path parameter to `:FzfPreviewDirectoryFiles` command (and fzf-preview internal functions) that will be added at the end of `g:fzf_preview_filelist_command` before listing files.

This way we can for example open files preview of the directory of the current file opened like so

```vim
nmap <silent> 0 :FzfPreviewDirectoryFiles <C-R>=expand('%:h')<CR><CR>
```