### PR TITLE
Add ability to jump to buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ nnoremap <silent> [fzf-p]l     :<C-u>FzfPreviewLocationList<CR>
 <C-t>
   Open tabedit
 
+<C-o>
+  Jump to buffer if already open. See :drop.
+  If g:fzf_preview_buffers_jump is set to 1 then it will open the buffer in
+  current window instead.
+
 <C-q>
   Build QuickFix
 
@@ -264,6 +269,9 @@ let g:fzf_preview_floating_window_rate = 0.9
 
 " floating window winblend value
 let g:fzf_preview_floating_window_winblend = 15
+
+" jump to the buffers by default, when possible
+let g:fzf_preview_buffers_jump = 0
 
 " Commands used for fzf preview.
 " The file name selected by fzf becomes {}

--- a/autoload/fzf_preview/resource_processor.vim
+++ b/autoload/fzf_preview/resource_processor.vim
@@ -21,6 +21,7 @@ function! fzf_preview#resource_processor#get_default_processors() abort
   let processors[g:fzf_preview_vsplit_key_map] = function('fzf_preview#resource_processor#vsplit')
   let processors[g:fzf_preview_tabedit_key_map] = function('fzf_preview#resource_processor#tabedit')
   let processors[g:fzf_preview_build_quickfix_key_map] = function('fzf_preview#resource_processor#export_quickfix')
+  let processors[g:fzf_preview_drop_key_map] = function('fzf_preview#resource_processor#drop')
 
   return processors
 endfunction
@@ -43,7 +44,11 @@ function! fzf_preview#resource_processor#reset_processors() abort
 endfunction
 
 function! fzf_preview#resource_processor#edit(lines) abort
-  call s:open_files('edit', a:lines)
+  if g:fzf_preview_buffers_jump
+    call s:open_files('drop', a:lines)
+  else
+    call s:open_files('edit', a:lines)
+  endif
 endfunction
 
 function! fzf_preview#resource_processor#split(lines) abort
@@ -56,6 +61,15 @@ endfunction
 
 function! fzf_preview#resource_processor#tabedit(lines) abort
   call s:open_files('tabedit', a:lines)
+endfunction
+
+function! fzf_preview#resource_processor#drop(lines) abort
+  " If we drop to file by default, then we reverse the behavior of ctrl-o
+  if g:fzf_preview_buffers_jump
+    call s:open_files('edit', a:lines)
+  else
+    call s:open_files('drop', a:lines)
+  endif
 endfunction
 
 function! fzf_preview#resource_processor#export_quickfix(lines) abort

--- a/doc/fzf_preview_vim.txt
+++ b/doc/fzf_preview_vim.txt
@@ -514,6 +514,14 @@ DEPRECATED: Use g:fzf_preview_custom_default_processors
 
 
 DEPRECATED: Use g:fzf_preview_custom_default_processors
+*g:fzf_preview_drop_key_map*
+    This map is used when drop command executed.
+    Options are a string passed directly to fzf's "--expect" option.
+
+    Default value is 'ctrl-o'
+
+
+DEPRECATED: Use g:fzf_preview_custom_default_processors
 *g:fzf_preview_build_quickfix_key_map*
     This map is used when building QuickFix from fzf.
     Options are a string passed directly to fzf's "--expect" option.

--- a/plugin/fzf_preview.vim
+++ b/plugin/fzf_preview.vim
@@ -112,6 +112,10 @@ if !exists('g:fzf_preview_tabedit_key_map')
   let g:fzf_preview_tabedit_key_map = 'ctrl-t'
 endif
 
+if !exists('g:fzf_preview_drop_key_map')
+  let g:fzf_preview_drop_key_map = 'ctrl-o'
+endif
+
 if !exists('g:fzf_preview_build_quickfix_key_map')
   let g:fzf_preview_build_quickfix_key_map = 'ctrl-q'
 endif

--- a/plugin/fzf_preview.vim
+++ b/plugin/fzf_preview.vim
@@ -128,6 +128,10 @@ if !exists('g:fzf_preview_fzf_preview_window_option')
   let g:fzf_preview_fzf_preview_window_option = ''
 endif
 
+if !exists('g:fzf_preview_buffers_jump')
+  let g:fzf_preview_buffers_jump = 0
+endif
+
 if !exists('g:fzf_preview_filelist_postprocess_command')
   let g:fzf_preview_filelist_postprocess_command = ''
 endif


### PR DESCRIPTION
Using ctrl-o you can jump (:drop) to the buffer if it's already open.
Using ctrl-d you can delete the selected buffer(s)

Add the option g:fzf_preview_buffers_jump (default 0) to drop to the
buffer by default. If set to 1 the behavior of ctrl-o will be to open
the buffer in the current window instead.