### PR TITLE
preview_fzf_grep: optional support for columns

### DIFF
--- a/bin/preview_fzf_grep
+++ b/bin/preview_fzf_grep
@@ -9,7 +9,7 @@ import os
 bat_theme = (os.environ.get('FZF_PREVIEW_PREVIEW_BAT_THEME', 'ansi-dark'))
 
 GREP_OUTPUT_REGEX = re.compile(
-    r'(?P<dev_icon>.\s\s)?(?P<file_name>.+):(?P<line_num>\d+)(:(?P<match>.*))?'
+    r'(?P<dev_icon>.\s\s)?(?P<file_name>[^:]+):(?P<line_num>\d+)(:(?P<col>\d+))?(:(?P<match>.*))?'
 )
 CLEAN_LINE_REGEX = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
@@ -27,7 +27,7 @@ if not match:
     )
     sys.exit(1)
 
-file_name = match.group('file_name').split(':')[0]
+file_name = match.group('file_name')
 line_num = int(match.group('line_num'))
 start = max(line_num - 10, 1)
 last = line_num + 100


### PR DESCRIPTION
Hey there! I was trying to reuse the grep preview script for integrating with some output from the lsp client that includes the column number. Keeping the column is important so I can jump to the precise location in the 'sink' function. I can move the column elsewhere in the line, but I think that would be weird.

I'm not familiar with the use case for having a `:` match the file group though, so please let me know if I'm messing something up.