### PR TITLE
Fix can't work vim-bookmarks source when not readable files are marked

### DIFF
--- a/autoload/fzf_preview/remote/resource/bookmarks.vim
+++ b/autoload/fzf_preview/remote/resource/bookmarks.vim
@@ -10,7 +10,7 @@ function! s:bookmarks_format_line(line) abort
   let line = split(a:line, ':')
   let filename = fnamemodify(line[0], ':.')
   if !filereadable(filename)
-    return ''
+    return { 'file': '' }
   endif
 
   let line_number = line[1]


### PR DESCRIPTION
Thanks for useful plugin.

This PR is fix unexpected behavior of vim-bookmarks integration when not readable file are bookmarked. (e.g. directory list, removed file)