### PR TITLE
add --no-ext-diff avoid external diff like difft

### DIFF
--- a/plugin/fzf_preview.vim
+++ b/plugin/fzf_preview.vim
@@ -67,8 +67,8 @@ if !exists('g:fzf_preview_git_status_command')
 endif
 
 if !exists('g:fzf_preview_git_status_preview_command')
-  let g:fzf_preview_git_status_preview_command =  '[[ $(git diff --cached -- {-1}) != "" ]] && git diff --cached --color=always -- {-1} || ' .
-  \ '[[ $(git diff -- {-1}) != "" ]] && git diff --color=always -- {-1} || ' .
+  let g:fzf_preview_git_status_preview_command =  '[[ $(git --no-pager diff --no-ext-diff --cached -- {-1}) != "" ]] && git --no-pager diff --no-ext-diff --cached --color=always -- {-1} || ' .
+  \ '[[ $(git --no-pager diff --no-ext-diff -- {-1}) != "" ]] && git --no-pager diff --no-ext-diff --color=always -- {-1} || ' .
   \ g:fzf_preview_command
 endif
 


### PR DESCRIPTION
when using external difftool in .gitconfig like [difftastic](https://github.com/Wilfred/difftastic) , GitStatus preview lost syntax highlight. 

option  --no-ext-diff  can prevent git from using external difftool from .gitconfig. so I try to fix that with appending that option.